### PR TITLE
优化 工单设置边栏的样式

### DIFF
--- a/app/javascript/frontend/issues.scss
+++ b/app/javascript/frontend/issues.scss
@@ -40,5 +40,5 @@
 }
 
 .text-issue-priority-normal {
-  color: $secondary;
+  color: inherit;
 }

--- a/app/views/projects/issues/_attribute_info.html.erb
+++ b/app/views/projects/issues/_attribute_info.html.erb
@@ -1,6 +1,6 @@
 <%= content_tag "div", data: { controller: "inline-edit", template: template } do %>
   <div class="d-flex">
-    <span class="h5"><%=h Issue, attribute_name %></span>
+    <span class="small text-muted"><%=h Issue, attribute_name %></span>
     <span class="ms-auto"><%= link_to(content_tag(:i, '', class: 'far fa-edit'), "javascript:void(0)", data: { action: "click->inline-edit#replace" }) if can? :edit, issue %></span>
   </div>
   <%= yield %>

--- a/app/views/projects/issues/show.html.erb
+++ b/app/views/projects/issues/show.html.erb
@@ -102,7 +102,7 @@
     </button>
 
     <div class="collapse d-md-block" id="issueDetailCollapse">
-      <h5 class="mt-2"><%=h Issue, :created_at %></h5>
+      <span class="small text-muted mt-2 d-flex"><%=h Issue, :created_at %></span>
       <span><%=l @issue.created_at, format: :long %></span>
       <hr>
       <% form = capture do %>


### PR DESCRIPTION
淡化标题，突出字段内容
<img width="1407" alt="截屏2021-12-13 10 45 19" src="https://user-images.githubusercontent.com/14367682/145744451-5cc2323e-013d-403f-aeb0-6f91652569fb.png">
